### PR TITLE
Vanders/test kitchen

### DIFF
--- a/.cyclid.json
+++ b/.cyclid.json
@@ -1,25 +1,26 @@
 {
-  "name": "example-chef-project",
-  "environment": {
-    "os": "ubuntu_trusty",
-    "packages": [
+  "name":"example-chef-project",
+  "environment":{
+    "os":"ubuntu_trusty",
+    "packages":[
       "git",
-      "curl"
+      "curl",
+      "docker.io"
     ]
   },
-  "sources": [
+  "sources":[
     {
-      "type": "git",
-      "url": "https://github.com/Cyclid/example-chef-project.git"
+      "type":"git",
+      "url":"https://github.com/Cyclid/example-chef-project.git"
     }
   ],
-  "stages": [
+  "stages":[
     {
-      "name": "install-chefdk",
-      "steps": [
+      "name":"install-chefdk",
+      "steps":[
         {
-          "action": "script",
-          "script": [
+          "action":"script",
+          "script":[
             "#!/bin/bash -x",
             "curl -s -L -O https://packages.chef.io/stable/ubuntu/12.04/chefdk_0.18.30-1_amd64.deb || exit 1",
             "sudo dpkg -i chefdk_0.18.30-1_amd64.deb || exit 1"
@@ -28,74 +29,74 @@
       ]
     },
     {
-      "name": "lint",
-      "steps": [
+      "name":"lint",
+      "steps":[
         {
-          "action": "command",
-          "cmd": "chef exec cookstyle",
-          "path": "%{workspace}/example-chef-project"
+          "action":"command",
+          "cmd":"chef exec cookstyle",
+          "path":"%{workspace}/example-chef-project"
         }
       ]
     },
     {
-      "name": "chefspec",
-      "steps": [
+      "name":"chefspec",
+      "steps":[
         {
-          "action": "command",
-          "cmd": "chef exec rspec",
-          "path": "%{workspace}/example-chef-project"
+          "action":"command",
+          "cmd":"chef exec rspec",
+          "path":"%{workspace}/example-chef-project"
         }
       ]
     },
     {
-      "name": "test-kitchen",
-      "steps": [
+      "name":"test-kitchen",
+      "steps":[
         {
-          "action": "command",
-          "cmd": "echo chef exec kitchen test",
-          "path": "%{workspace}/example-chef-project"
+          "action":"command",
+          "cmd":"chef exec kitchen test --no-color",
+          "path":"%{workspace}/example-chef-project"
         }
       ]
     },
     {
-      "name": "success",
-      "steps": [
+      "name":"success",
+      "steps":[
         {
-          "action": "log",
-          "message": "Job %{organization}/%{job_name} (job #%{job_id}) completed successfully."
+          "action":"log",
+          "message":"Job %{organization}/%{job_name} (job #%{job_id}) completed successfully."
         }
       ]
     },
     {
-      "name": "failure",
-      "steps": [
+      "name":"failure",
+      "steps":[
         {
-          "action": "log",
-          "message": "Job %{organization}/%{job_name} (job #%{job_id}) failed."
+          "action":"log",
+          "message":"Job %{organization}/%{job_name} (job #%{job_id}) failed."
         }
       ]
     }
   ],
-  "sequence": [
+  "sequence":[
     {
-      "stage": "install-chefdk",
-      "on_success": "lint",
-      "on_failure": "failure"
+      "stage":"install-chefdk",
+      "on_success":"lint",
+      "on_failure":"failure"
     },
     {
-      "stage": "lint",
-      "on_success": "chefspec",
-      "on_failure": "failure"
+      "stage":"lint",
+      "on_success":"chefspec",
+      "on_failure":"failure"
     },
     {
-      "stage": "chefspec",
-      "on_success": "test-kitchen",
-      "on_failure": "failure"
+      "stage":"chefspec",
+      "on_success":"test-kitchen",
+      "on_failure":"failure"
     },
     {
-      "stage": "test-kitchen",
-      "on_success": "success",
-      "on_failure": "failure"
+      "stage":"test-kitchen",
+      "on_success":"success",
+      "on_failure":"failure"
     }
   ]
-} 
+}

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,15 +1,21 @@
 ---
 driver:
-  name: <%= ENV['KITCHEN_DRIVER'] || 'vagrant' %>
+  name: dokken
+  chef_version: latest
+
+transport:
+  name: dokken
 
 provisioner:
-  name: chef_zero
+  name: dokken
 
 verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-14.04
+  - name: ubuntu-trusty
+    driver:
+      image: ubuntu:trusty
 
 suites:
   - name: default

--- a/cyclid.yaml
+++ b/cyclid.yaml
@@ -1,0 +1,56 @@
+---
+name: example-chef-project
+environment:
+  os: ubuntu_trusty
+  packages:
+  - git
+  - curl
+  - docker.io
+sources:
+- type: git
+  url: https://github.com/Cyclid/example-chef-project.git
+stages:
+- name: install-chefdk
+  steps:
+  - action: script
+    script:
+    - '#!/bin/bash -x'
+    - curl -s -L -O https://packages.chef.io/stable/ubuntu/12.04/chefdk_0.18.30-1_amd64.deb
+      || exit 1
+    - sudo dpkg -i chefdk_0.18.30-1_amd64.deb || exit 1
+- name: lint
+  steps:
+  - action: command
+    cmd: chef exec cookstyle
+    path: '%{workspace}/example-chef-project'
+- name: chefspec
+  steps:
+  - action: command
+    cmd: chef exec rspec
+    path: '%{workspace}/example-chef-project'
+- name: test-kitchen
+  steps:
+  - action: command
+    cmd: chef exec kitchen test --no-color
+    path: '%{workspace}/example-chef-project'
+- name: success
+  steps:
+  - action: log
+    message: 'Job %{organization}/%{job_name} (job #%{job_id}) completed successfully.'
+- name: failure
+  steps:
+  - action: log
+    message: 'Job %{organization}/%{job_name} (job #%{job_id}) failed.'
+sequence:
+- stage: install-chefdk
+  on_success: lint
+  on_failure: failure
+- stage: lint
+  on_success: chefspec
+  on_failure: failure
+- stage: chefspec
+  on_success: test-kitchen
+  on_failure: failure
+- stage: test-kitchen
+  on_success: success
+  on_failure: failure

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ license 'apache2'
 description 'An example Chef cookbook'
 long_description 'An example cookbook that demonstrates how to combine Chef with Cyclid'
 version '1.0.0'
+
+depends 'apt'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,4 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'apt'
+
 package 'nginx'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -21,7 +21,7 @@ require 'spec_helper'
 describe 'example-chef-project::default' do
   context 'When all attributes are default, on an unspecified platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04')
       runner.converge(described_recipe)
     end
 


### PR DESCRIPTION
Enable test-kitchen on top of Docker using the kitchen-docken driver.
Make sure that the example & tests all pass under the latest ChefDK and inside test-kitchen.
Format the JSON job file and also add the YAML equivalent.